### PR TITLE
rerouted product details from home

### DIFF
--- a/src/components/products/ProductItem.js
+++ b/src/components/products/ProductItem.js
@@ -1,9 +1,11 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 export default function ProductItem(props) {
   return (
     <>
-    <a href={props.item.url}> •Name: {props.item.name} •Created At: {props.item.created_at}</a> <br/>
+    {/* <a href={props.item.url}> •Name: {props.item.name} •Created At: {props.item.created_at}</a> <br/> */}
+    •Name: <Link to={`/products/${props.item.id}`}>{props.item.name}</Link>  •Created At: {props.item.created_at} <br/>
     </>
   )
 }


### PR DESCRIPTION
# Description
Changed a tag to Link routing to Product Details View 
Fixes # (issue)
Routing to detail view vs API view in browser
## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
# Testing Instructions
git fetch --all
git checkout ms-reroute-product-details-from-home
Go to home page
Click on product name
Make sure it routes to product detail
# Checklist:
- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new warnings or errors
- [ X] I have added test instructions that prove my fix is effective or that my feature works
