### PR TITLE
feat: user can delete a payment type

### DIFF
--- a/src/components/helpers/APIManager.js
+++ b/src/components/helpers/APIManager.js
@@ -48,6 +48,14 @@ export default {
             body: JSON.stringify(newItem)
         })
     .then(response => response.json())
+    },
+    deleteOne(endpoint, id){
+        return fetch(`${Settings.remote_URL}/${endpoint}/${id}`,{
+            method: "DELETE",
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Token ${sessionStorage.getItem(Settings.token_name)}`,
+            }})
     }
     }
 

--- a/src/components/home/MyAccount.js
+++ b/src/components/home/MyAccount.js
@@ -23,8 +23,12 @@ export default function MyAccount(props) {
     .then(setCustomers)
     
   }
+
+  const deletePayment = id => {
+    APIManager.deleteOne('paymenttypes', id)
+  }
 // useEffect like a superpowered componentDidMount; getPayments runs; dependency array with multiple variables or functions
-  useEffect(getPayments, []);
+  useEffect(getPayments, [deletePayment]);
   useEffect(getCustomers, []);
 
 
@@ -33,7 +37,7 @@ export default function MyAccount(props) {
           <main className="profile">
             <Link to="/paymenttype/new">Add New Payment Type</Link>
             <CustomerList {...props} customers={customers} />
-            <PaymentList {...props} payments={payments}/>
+            <PaymentList {...props} payments={payments} deletePayment={deletePayment}/>
           </main>
         </>
   )

--- a/src/components/home/Payment.js
+++ b/src/components/home/Payment.js
@@ -6,9 +6,10 @@ export default function Payment(props) {
             <section className="payment">
                 <p>
                 {props.payment.merchant_name}<br />
-                {props.payment.acct_no}<br />
+                ************{props.payment.acct_no.slice(12,16)}<br />
                 {props.payment.expiration_date.slice(0,10)}<br />
                 </p>
+                <button onClick={()=>props.deletePayment(props.payment.id)}>Delete</button>
             </section>
         </React.Fragment>
     )

--- a/src/components/home/PaymentList.js
+++ b/src/components/home/PaymentList.js
@@ -12,6 +12,7 @@ export default function PaymentList(props) {
               <Payment
                 key={payment.id}                
                 payment={payment}
+                deletePayment={props.deletePayment}
               />)
           }
         </article>


### PR DESCRIPTION
# Description

User can delete a payment type from their account.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
```
git fetch -all
git checkout rb-deletepayment
npm start
```
1. Open the react app and go to `profile` view
1. Add a payment if you don't have one already
1. You should now see an option to `DELETE` the payment
1. Click the delete button and you should see it DESTROYED from existence

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
