### PR TITLE
Ms add product to cart

### DIFF
--- a/src/components/home/ProductDetail.js
+++ b/src/components/home/ProductDetail.js
@@ -1,17 +1,16 @@
 import React from 'react'
 import { useState, useEffect } from 'react'
 import APIManager from '../helpers/APIManager'
+import { useHistory } from 'react-router-dom'
 
 export default function ProductDetail(props) {
 
 
-    // add product to order - logic check for open order if there is none  create it the can be only one
-    // from product details
-    // first write a get for order by customer where there is no attached payment type
-
     const [productdetail, setProductDetail] = useState({
         product_type: {}
     })
+
+    const history = useHistory()
 
     useEffect(() => {
         APIManager.getOne('products', props.match.params.productId)
@@ -19,6 +18,12 @@ export default function ProductDetail(props) {
                 setProductDetail(response)
             })
     }, [])
+
+    const AddItem = (id) => {
+        APIManager.createNew('orderproducts/cart', {"product_id": id})
+        .then(() => history.push("/orders"))
+    }
+
     return (
         <>
             <h1>{productdetail.name}</h1>
@@ -28,7 +33,7 @@ export default function ProductDetail(props) {
             <p>{productdetail.location}</p>
             <p>{productdetail.image_path}</p>
             <p>{productdetail.product_type.name}</p>
-            <button>Add Item to Cart</button>
+            <button onClick={() => AddItem(productdetail.id)}>Add Item to Cart</button>
         </>
     )
 }

--- a/src/components/home/ProductDetail.js
+++ b/src/components/home/ProductDetail.js
@@ -4,6 +4,11 @@ import APIManager from '../helpers/APIManager'
 
 export default function ProductDetail(props) {
 
+
+    // add product to order - logic check for open order if there is none  create it the can be only one
+    // from product details
+    // first write a get for order by customer where there is no attached payment type
+
     const [productdetail, setProductDetail] = useState({
         product_type: {}
     })
@@ -16,13 +21,14 @@ export default function ProductDetail(props) {
     }, [])
     return (
         <>
-            <h1>{productdetail.name}</h1> 
+            <h1>{productdetail.name}</h1>
             <p>{productdetail.price}</p>
             <p>{productdetail.description}</p>
             <p>{productdetail.quantity}</p>
             <p>{productdetail.location}</p>
-            <p>{productdetail.image_path}</p> 
+            <p>{productdetail.image_path}</p>
             <p>{productdetail.product_type.name}</p>
+            <button>Add Item to Cart</button>
         </>
     )
 }


### PR DESCRIPTION
# Description
User can click on add product to order button from a product detail page
If that customer has no open orders, a new open order will be created
The product will be added to the current user's open order

## Type of change
Please delete options that are not relevant.
- [ X] New feature (non-breaking change which adds functionality)
# Testing Instructions
git fetch --all
git checkout ms-add-product-to-cart
1. make sure you have checked out ms-check-open-order in the API PR and server is running
2. make sure you are logged in
3. run python manage.py makemigrations
4. run python manage.py migrate
5. Go to home page 
6. Click on Product Name
7. Click on Add Item to Cart
8. Make sure that Product appears in TablePlus or DBeaver as part of an open order
9. Make sure once you have added the item that the page reroutes to /orders
# Checklist:
- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] My changes generate no new warnings or errors
- [X ] I have added test instructions that prove my fix is effective or that my feature works
